### PR TITLE
AUS_ADM2 gbOpen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@ sourceData/gbHumanitarian/IDN_ADM2.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/PHL_ADM1.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/PHL_ADM2.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/PHL_ADM3.zip filter=lfs diff=lfs merge=lfs -text
-sourceData/gbOpen/AUS_ADM2.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/AUT_ADM3.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/AUT_ADM4.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/BGD_ADM3.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
<!--- Thank you for your submission to geoBoundaries! -->
<!--- If you are submitting a boundary, please make sure to include the ISO code and ADM level -->
<!--- We require full data lineage for all products, but give us your source and we'll do the legwork to hunt down everything we can! -->

## Why do we need this boundary?  
<!--- If this is in response to a github issue, just link it here. -->
<!--- Otherwise, let us know why this boundary is better than what's in the current database. -->
Update AUS_ADM2 with 2022 source. 
Fixes previous boundaries by changing Statistical Area 3 for Local Goverment Area. 
Remove file from git lfs.

## Anything Unusual?
<!--- Please describe any known complications with your submission. -->
<!--- You can also include anything else we need to know while assessing this data. -->