### PR TITLE
CHE_ADM3 gbOpen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,7 +16,6 @@ sourceData/gbOpen/AUT_ADM4.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/BGD_ADM3.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/BGD_ADM4.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/BRA_ADM2.zip filter=lfs diff=lfs merge=lfs -text
-sourceData/gbOpen/CHE_ADM3.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/CHL_ADM3.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/COL_ADM2.zip filter=lfs diff=lfs merge=lfs -text
 sourceData/gbOpen/CZE_ADM3.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
<!--- Thank you for your submission to geoBoundaries! -->
<!--- If you are submitting a boundary, please make sure to include the ISO code and ADM level -->
<!--- We require full data lineage for all products, but give us your source and we'll do the legwork to hunt down everything we can! -->

## Why do we need this boundary?  
<!--- If this is in response to a github issue, just link it here. -->
<!--- Otherwise, let us know why this boundary is better than what's in the current database. -->
Update CHE_ADM3 with 2022 source.
Removed polygons from Italy, Germany, and Liechtenstein.
Removed from git lfs.

## Anything Unusual?
<!--- Please describe any known complications with your submission. -->
<!--- You can also include anything else we need to know while assessing this data. -->