### PR TITLE
RUS_ADM0

### DIFF
--- a/sourceData/gbOpen/RUS_ADM0.zip
+++ b/sourceData/gbOpen/RUS_ADM0.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca1ad06b7b107843983bcbeb553d15a398f151955109d1dca4ae5e7b7295ffe1
-size 2136092
+oid sha256:53a2119f3771b634eece172bd07384ee76a66f680ab489e2db6cd4b5cb1fb5d9
+size 15061660

--- a/sourceData/gbOpen/RUS_ADM0.zip
+++ b/sourceData/gbOpen/RUS_ADM0.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53a2119f3771b634eece172bd07384ee76a66f680ab489e2db6cd4b5cb1fb5d9
-size 15061660
+oid sha256:52b048365fa311e68b79e56db31764b9d2d50bdfccb20f95b5916386bd522d2e
+size 14532458


### PR DESCRIPTION
## Why do we need this boundary?  
In response to #3654 (RUS_ADM0 has significant amount of area in territorial waters)

## Anything Unusual?
Created by dissolving RUS_ADM1 from gbOpen