### PR TITLE
SJM_ADM0

### DIFF
--- a/sourceData/gbOpen/SJM_ADM0.zip
+++ b/sourceData/gbOpen/SJM_ADM0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad70d8ef8c24d4c1e9bec1ac6a55ff855095809352fb40a4cc1dd880db6257c0
+size 6805790


### PR DESCRIPTION
## Why do we need this boundary?  
#3657  (gbOpen currently has no data for SJM ADM0)

## Anything Unusual?
Created using vectorized output from land values in Sentinel2