### PR TITLE
SJM_ADM1

### DIFF
--- a/sourceData/gbOpen/SJM_ADM1.zip
+++ b/sourceData/gbOpen/SJM_ADM1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cd3ba1403a68fbe0dd79035f1758654dcd303d1b35b6cb37b0da627a9e29bff
+size 6807510


### PR DESCRIPTION
## Why do we need this boundary?  
#3658 (gbOpen currently has no data for SJM ADM1)

## Anything Unusual?
Created using vectorized output from land values in Sentinel2