### PR TITLE
SJM_ADM1 (fixed zip)

### DIFF
--- a/sourceData/gbOpen/SJM_ADM1.zip
+++ b/sourceData/gbOpen/SJM_ADM1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:742c284b9fbd70d794f75ac12bed9a8add4409bc469b5d0c3de8459551b9490f
+size 6629838


### PR DESCRIPTION
## Why do we need this boundary?  
#3666 (gbOpen currently has no data for SJM ADM0)

## Anything Unusual?
Created using vectorized output from land values in Sentinel2