### PR TITLE
MDV_ADM0

### DIFF
--- a/sourceData/gbOpen/MDV_ADM0.zip
+++ b/sourceData/gbOpen/MDV_ADM0.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37082f8ae0336069b51d8d47b93f2f04bbc32ccc058822f2d2488a1d995e057e
+oid sha256:3ccb30efc2e89c59f769904f53dfbb158b32888bcba97b124104d0b1724a1602
 size 661489

--- a/sourceData/gbOpen/MDV_ADM0.zip
+++ b/sourceData/gbOpen/MDV_ADM0.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f309da4dcd364eb9a3686432e6ca474f223cfbc491a5b1cf626335be7177411
-size 5873413
+oid sha256:37082f8ae0336069b51d8d47b93f2f04bbc32ccc058822f2d2488a1d995e057e
+size 661489


### PR DESCRIPTION
## Why do we need this boundary?  
This version of the boundary came from a vectorized version of Sentinel2 data for Maldives, which includes more of the area than previously. 

The previous version:
<img width="249" alt="Screenshot 2024-05-15 at 11 03 23 AM" src="https://github.com/wmgeolab/geoBoundaries/assets/144378377/c373efb3-0aa8-4df7-8d31-bc3a013185f9">

Possible addition:
<img width="199" alt="Screenshot 2024-05-15 at 11 03 39 AM" src="https://github.com/wmgeolab/geoBoundaries/assets/144378377/cda5307e-dde3-41ab-899f-dea7e903a678">

## Anything Unusual?
No. 