### PR TITLE
Dissolve by AFG_ADM2

### DIFF
--- a/sourceData/gbOpen/AFG_ADM1.zip
+++ b/sourceData/gbOpen/AFG_ADM1.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c97c48064b660e41a05fe4c67f6d867d1ce909bb03de74c34d6579c531a24851
-size 110775
+oid sha256:0f695f0b424dfb0deb4052edbcdac780e5754435bf65dea63c0496dfaff280df
+size 1056186


### PR DESCRIPTION
## Why do we need this boundary?  
<!--- If this is in response to a github issue, just link it here. -->
<!--- Otherwise, let us know why this boundary is better than what's in the current database. -->
The current data for AFG_ADM1 in gbOpen has very low resolution and comparing ADM1 to ADM2 creates significant mismatches.

Current data
<img width="843" alt="Screenshot 2024-05-15 at 12 58 33 PM" src="https://github.com/wmgeolab/geoBoundaries/assets/144378377/5bce0d37-5361-4776-89dd-984e043fa5c0">

Proposed data
<img width="836" alt="Screenshot 2024-05-15 at 12 58 49 PM" src="https://github.com/wmgeolab/geoBoundaries/assets/144378377/9083adf4-b7f3-4146-96b6-f58c7a8e5ade">

## Anything Unusual?
I created this from a district-by-district dissolve of the data currently in [AFG_ADM2 on gbOpen](https://github.com/wmgeolab/geoBoundaries/blob/main/releaseData/gbOpen/AFG/ADM2/geoBoundaries-AFG-ADM2-all.zip).