### PR TITLE
Add CXR_ADM0

### DIFF
--- a/sourceData/gbOpen/CCK_ADM0.zip
+++ b/sourceData/gbOpen/CCK_ADM0.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9451404a1623925cef982a74943d10c3af9dd75ccc86ea0c07ca824aeaa28a
+size 322669


### PR DESCRIPTION
## Why do we need this boundary?  
AUS_ADM0 in gbOpen currently includes Christmas Island, but we would like to add CCK to the ISO list, starting with this ADM0 data.

## Anything Unusual?
Created by vectorizing Sentinel2 imagery.